### PR TITLE
Upgrade anothrNick/github-tag-action to version 1.71

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -19,7 +19,7 @@ runs:
     - name: Bump version and push tag
       if: ${{ steps.tag.outputs.tag == '' }}
       id: tag_version
-      uses: anothrNick/github-tag-action@1.36.0
+      uses: anothrNick/github-tag-action@1.71.0
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         WITH_V: false


### PR DESCRIPTION
This pull request includes an update to the `action.yaml` file to use a newer version of the `github-tag-action`.

* [`action.yaml`](diffhunk://#diff-fab4d7fb461bc6fbe9587f6c03fff98102b1c744145edcf2a993f2ff7cb05a0dL22-R22): Updated the `github-tag-action` from version `1.36.0` to `1.71.0`.
* 

Mitigate these warnings
![image](https://github.com/user-attachments/assets/21ac5775-9c81-4101-ad63-5ad8f7a130e9)


https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/